### PR TITLE
[BUGFIX] Fix menu hierarchy in Quickstart

### DIFF
--- a/Documentation/QuickInstall/Composer/Index.rst
+++ b/Documentation/QuickInstall/Composer/Index.rst
@@ -10,7 +10,8 @@ Install TYPO3 via composer
 
 .. attention::
 
-   The recommended way of installing TYPO3 is via composer.
+   The recommended way of installing TYPO3 is via composer, as described on
+   this page.
 
 
 To create a new TYPO3 project use the TYPO3 Base Distribution::
@@ -38,12 +39,10 @@ Point the document root of your web server to the `public` folder.
 After composer installation continue with the steps in :ref:`the-install-tool`
 
 If you do not want to use composer, follow the :ref:`package installation
-guide`.
+guide <get-and-unpack-the-typo3-package>`.
 
+Next Steps
+==========
 
-.. toctree::
-   :titlesonly:
-
-   ../GetAndUnpack/Index
-
+Continue with :ref:`the-install-tool`.
 

--- a/Documentation/QuickInstall/GetAndUnpack/Index.rst
+++ b/Documentation/QuickInstall/GetAndUnpack/Index.rst
@@ -7,6 +7,10 @@
 Get and Unpack the TYPO3 Package
 ================================
 
+.. attention::
+
+   This is an alternative method of installation to composer installation.
+   The recommended way of installing TYPO3 is :ref:`via composer <install-via-composer>`.
 
 .. _installation-unix:
 

--- a/Documentation/QuickInstall/Index.rst
+++ b/Documentation/QuickInstall/Index.rst
@@ -23,4 +23,5 @@ Pre-Requisites:
    :titlesonly:
 
    Composer/Index
+   GetAndUnpack/Index
    TheInstallTool/Index


### PR DESCRIPTION
Add manual installation on same menu level as composer,
not as subchapter of composer.

Add additial notes for clarification.

Fix link.

Resolves: #51