### PR TITLE
Language corrections

### DIFF
--- a/Documentation/In-depth/Distributions/Index.rst
+++ b/Documentation/In-depth/Distributions/Index.rst
@@ -45,7 +45,7 @@ to have a "look around" and get more familiar with the CMS.
 
 .. _installing-distributions:
 
-Installing Distributions without Composer
+Installing Distributions Without Composer
 =========================================
 
 For testing and evaluation we recommend that you use the Introduction Package,
@@ -61,7 +61,7 @@ using a Distribution. You can then start with a completely empty
 installation of TYPO3.
 
 
-Installing Distributions with Composer
+Installing Distributions With Composer
 ======================================
 
 To install the Introduction Package or any other distribution on a Composer

--- a/Documentation/In-depth/SystemRequirements/Index.rst
+++ b/Documentation/In-depth/SystemRequirements/Index.rst
@@ -31,14 +31,14 @@ Should you encounter problems, the ":ref:`troubleshooting`" section at the end
 of this document will help.
 
 
-Database environment
+Database Environment
 ====================
 
 TYPO3 works with database management systems in the above mentioned versions.
 The InnoDB engine is required to be enabled in MySQL.
 
 
-Required database privileges
+Required Database Privileges
 ----------------------------
 
 The database user needs at least the following privileges on the TYPO3
@@ -55,7 +55,7 @@ It is recommended to also grant the following privileges:
 * EXECUTE, CREATE ROUTINE, ALTER ROUTINE
 
 
-Web server environment
+Web Server Environment
 ======================
 
 Apache
@@ -68,7 +68,7 @@ Apache
   urls)
 
 
-PHP environment
+PHP Environment
 ---------------
 
 * memory_limit set to at least 256M recommended
@@ -78,7 +78,7 @@ PHP environment
 * max_input_vars set to at least 1500
 
 
-PHP required extensions
+PHP Required Extensions
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Your PHP needs to support the following extensions. Install will check if these

--- a/Documentation/In-depth/ThePackageInDetail/Index.rst
+++ b/Documentation/In-depth/ThePackageInDetail/Index.rst
@@ -10,10 +10,10 @@ The Package in Detail
 
 .. _typo3-folders-and-documents:
 
-TYPO3 Folders and Files on root level
+TYPO3 Folders and Files on Root Level
 =====================================
 
-The following files and folders are part of the TYPO3 package in a composer
+The following files and folders are part of the TYPO3 package in a Composer
 based installation.
 
 :file:`public/`
@@ -23,10 +23,10 @@ based installation.
   contains system files, like caches, logs, sessions...
 
 :file:`vendor/`
-  the composer vendor directory contains third-party packages, libraries etc.
+  the Composer vendor directory contains third-party packages, libraries etc.
 
-The 'public/' folder
---------------------
+The 'public' Folder
+-------------------
 
 The following files and folders will be created in the public folder during the
 installation of TYPO3:
@@ -46,7 +46,7 @@ installation of TYPO3:
 
 :file:`typo3conf/ext/`
   will hold the local extensions available for this installation, extensions
-  can be required via composer.
+  can be required via Composer.
 
 :file:`typo3conf/LocalConfiguration.php`
   is the main configuration file of your installation and the one the
@@ -72,8 +72,8 @@ installation of TYPO3:
 
 .. _custom-folders:
 
-The `var/` folder
------------------
+The `var` Folder
+----------------
 
 :file:`cache/`
   is where file based caches will be stored.
@@ -100,7 +100,7 @@ The `var/` folder
   acts as transient storage during file operations for example.
 
 
-Custom folders?
+Custom Folders?
 ===============
 
 Yes, just add whatever you like. Why not?

--- a/Documentation/In-depth/WhichPackageAndFormat/Index.rst
+++ b/Documentation/In-depth/WhichPackageAndFormat/Index.rst
@@ -3,7 +3,7 @@
 .. _which-package-and-which-file-format:
 
 ===============================
-Which Package and which Format?
+Which Package and Which Format?
 ===============================
 
 The recommended way of installing TYPO3 is via the PHP package manager `Composer`.
@@ -16,7 +16,7 @@ can be found here: `https://get.typo3.org <https://get.typo3.org>`_.
 
 .. _which-file-format-to-use:
 
-Which File Format to use
+Which File Format to Use
 ========================
 
 The TYPO3 Source package is available as a :file:`.zip` or

--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -8,7 +8,7 @@ Introduction
 
 .. _about-this-document:
 
-About this document
+About this Document
 ^^^^^^^^^^^^^^^^^^^
 
 This manual provides instructions on how to install and
@@ -27,7 +27,7 @@ to find out how to further configure and customize your installation of TYPO3.
 
 .. _what-s-new:
 
-What's new
+What's New
 ^^^^^^^^^^
 
 Updated the manual for TYPO3 CMS version 8.7.

--- a/Documentation/MigrateToComposer/BestPractices.rst
+++ b/Documentation/MigrateToComposer/BestPractices.rst
@@ -4,33 +4,34 @@
 .. _mig-composer-best-practices:
 
 ==============
-Best practices
+Best Practices
 ==============
 
-Run composer locally
+Run Composer Locally
 ====================
 
-You should not run composer on your live webspace. You always should run
-composer on your local machine, so you can test if everything worked
+You should not run `composer` on your live webspace. You should always run
+`composer` on your local or a dedicated deployment machine, so you can test
+if everything worked
 fine. After running your tests, you can deploy the :file:`vendor` and
 :file:`public` folder to your web server.
 
 To avoid conflicts between your local and your server's PHP version, you
 can define your server's PHP version in your :file:`composer.json` file
-(e.g. ``{"platform": {"php": "7.2"}}``), so composer will always check
+(e.g. ``{"platform": {"php": "7.2"}}``), so `composer` will always check
 the correct dependencies.
 
-Update packages
+Update Packages
 ===============
 
 After updating any packages, you always should commit your
 :file:`composer.lock` to your version control system and your co-workers
-should run ``composer install`` after checking out the updates.
+should run `composer install` after checking out the updates.
 
-Update all packages
+Update all Packages
 -------------------
 
-Run ``composer update`` without any other attributes, to update all
+Run `composer update` without any other attributes, to update all
 packages. Composer will always try to install the newest packages that
 match the defined version constraints.
 
@@ -40,38 +41,34 @@ match the defined version constraints.
     do not have proper version constraints in your :file:`composer.json`.
     You always should prefer to update your packages separately.
 
-Update single packages
+Update Single Packages
 ----------------------
 
-When you want to update single packages, you can call the ``update``
-command with the package name. You should always add
+When you want to update single packages, you can call `composer update`
+with the package name. You should always add
 ``--with-all-dependencies`` attribute to also update the required third
 party packages.
 
-Update TYPO3 core
+Update TYPO3 Core
 ~~~~~~~~~~~~~~~~~
 
-**Without "subtree split"**
-
-::
+Without "subtree split"::
 
     composer update typo3/cms --with-all-dependencies
 
-**With "subtree split"**
-
-::
+With "subtree split"::
 
     composer update typo3/cms-* --with-all-dependencies
 
-Update extensions like "news"
+Update Extensions Like "news"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ::
 
     composer update georgringer/news --with-all-dependencies
 
-Use "dev requirements"
-======================
+Use Dev Requirements
+====================
 
 Add packages with ``--dev`` attribute to add packages only to your local
 development environment. This is very useful for packages, you do not
@@ -89,10 +86,10 @@ attribute ``--no-dev``. So the dev requirements are not installed.
 
     composer install --no-dev
 
-Remove extensions
+Remove Extensions
 =================
 
-You can use the composer command ``remove`` to uninstall extensions or
+You can use the composer command `remove` to uninstall extensions or
 other composer packages.
 
 ::
@@ -104,18 +101,18 @@ control system.
 
 .. note::
 
-    Please be sure to disable extensions in TYPO3's Extension Manager, before removing them with composer.
+    Please be sure to disable extensions in TYPO3's Extension Manager, before removing them with `composer`.
     Or ensure to regenerate your :file:`typo3conf/PackageStates.php` file automatically, after removing the packages. You could use the
     `extension "typo3_console" <https://docs.typo3.org/typo3cms/extensions/typo3_console/CommandReference/Index.html#install-generatepackagestates>`__ for that
 
-Check for available updates
+Check for Available Updates
 ===========================
 
-Run ``composer outdated`` to see a list of available updates.
+Run `composer outdated` to see a list of available updates.
 
 .. _mig-composer-clear-typo3conf-ext-folder:
 
-Completely clear "typo3conf/ext" folder
+Completely Clear `typo3conf/ext` Folder
 =======================================
 
 In the "Migration Steps" chapter, this tutorial explained, how you can
@@ -128,7 +125,7 @@ If you are searching for a solution to keep your :file:`typo3conf/ext` folder
 clean and unify the extension handling even for your project's individual
 extension, this chapter might be useful.
 
-Define a local path repository
+Define a Local Path Repository
 ------------------------------
 
 Create a directory :file:`packages` in your project root folder and define
@@ -143,7 +140,7 @@ this folder as a repository of type "path" in your :file:`composer.json`::
         ]
     }
 
-Include your individual extensions from "packages" folder
+Include Your Individual Extensions From `packages` Folder
 ---------------------------------------------------------
 
 In the next step, you move all your individual extensions from
@@ -165,17 +162,17 @@ number, but tell composer to use the latest ``dev`` state.
     :file:`composer.json` and can be removed from your project's
     :file:`composer.json`.
 
-Exclude "typo3conf/ext" from version control system
+Exclude `typo3conf/ext` from Version Control System
 ---------------------------------------------------
 
 To finish your cleanup of "typo3conf/ext", you should keep the line
 ``/public/typo3conf/ext/*`` in your :file:`.gitignore`, but remove all lines,
 starting with ``!/public/typo3conf/ext/``.
 
-Useful packages and bundles
+Useful Packages and Bundles
 ===========================
 
-Simplify "subtree split" installations
+Simplify "Subtree Split" Installations
 --------------------------------------
 
 Instead of explicitly requiring each core extension, you can require
@@ -186,7 +183,7 @@ TYPO3 CMS Base Distribution
 ---------------------------
 
 Primarily, `typo3/cms-base-distribution <https://packagist.org/packages/typo3/cms-base-distribution>`__
-is not meant to be used with ``composer require``, but to really quickly start new composer based TYPO3 projects.
+is not meant to be used with `composer require`, but to really quickly start new composer based TYPO3 projects.
 
 Nevertheless, it's very good to have heard about it. If you're interested in more information, you should check
 the packages `README <https://github.com/TYPO3/TYPO3.CMS.BaseDistribution>`__.

--- a/Documentation/MigrateToComposer/Index.rst
+++ b/Documentation/MigrateToComposer/Index.rst
@@ -1,8 +1,8 @@
 .. include:: ../Includes.txt
 
-===================================================
-Convert TYPO3 project from non-composer to composer
-===================================================
+=================================
+Migrate TYPO3 Project to Composer
+=================================
 
 Contributed `initially 
 <https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-Installation/pull/25/>`__ 

--- a/Documentation/MigrateToComposer/MigrationSteps.rst
+++ b/Documentation/MigrateToComposer/MigrationSteps.rst
@@ -49,7 +49,7 @@ You must set the correct name of your web root folder in property ``web-dir``.
 Add All Required Packages to Your Project
 =========================================
 
-You can add all your required packages with the composer command `composer
+You can add all your required packages with the Composer command `composer
 require`. The full syntax is::
 
     composer require anyvendorname/anypackagename:version
@@ -65,10 +65,10 @@ found at https://getcomposer.org/doc/articles/versions.md
 
 In short:
 
-*  `^7.6` or `^7.6.0` tells composer to add newest package of
+*  `^7.6` or `^7.6.0` tells `composer` to add newest package of
    version 7.\* with at least 7.6.0, but not version 8.
 
-*  `~7.6.0` tells composer to add the newest package of version
+*  `~7.6.0` tells `composer` to add the newest package of version
    7.6.\* with at least 7.6.0, but not version 7.7.
 
 You have to decide by yourself, which syntax fits best to your needs.
@@ -119,7 +119,7 @@ Install Extensions from Packagist
 ---------------------------------
 
 You already know the TER and always used it to install extensions? Fine.
-But with composer, the **preferred way** is to install extensions
+But with Composer, the **preferred way** is to install extensions
 directly from `packagist.org <https://packagist.org>`__. This works great, when the maintainer uploaded them
 to there. Many well known extensions are already available.
 You only need to known the package name. There are multiple ways to find it:
@@ -128,8 +128,8 @@ Notice on Extension's TER Page
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Extension maintainers optionally can link their TYPO3 extension in TER with the
-correct composer key on `packagist.org <https://packagist.org>`__. Some maintainers already did that and if you
-search the extension in TER, you will see a message, which command and composer
+correct Composer key on `packagist.org <https://packagist.org>`__. Some maintainers already did that and if you
+search the extension in TER, you will see a message, which command and Composer
 key you can use to install this extension.
 
 |TER composer command|
@@ -144,7 +144,7 @@ Check in TER Satis
 
 If you search the extension in https://composer.typo3.org/satis.html and it's linked to
 `packagist.org <https://packagist.org>`__, they are marked as "abandoned" and you
-will see a message, which composer key should be used to install this extension.
+will see a message, which Composer key should be used to install this extension.
 
 |satis abandoned note|
 
@@ -192,7 +192,7 @@ Install Extension from TER
 --------------------------
 
 If the extension is not available on packagist, the good news is: All
-TER extensions are available via composer! That's, why we added
+TER extensions are available via Composer! That's, why we added
 `https://composer.typo3.org/` as repository to our :file:`composer.json`
 some lines above. There are little naming conventions:
 
@@ -202,7 +202,7 @@ some lines above. There are little naming conventions:
 
 **Example:**
 
-The extension `any_fancy_extension`'s auto generated composer package
+The extension `any_fancy_extension`'s auto generated Composer package
 name would be `typo3-ter/any-fancy-extension`. To add this extension in
 version 1.2.\*, type::
 
@@ -272,8 +272,8 @@ It's not necessary to move your project's site package to a dedicated
 Git repository to re-include it in your project. You can keep the files
 in your main project (e.g. :file:`public/typo3conf/ext/my_sitepackage`). There is
 only one thing to do; Because TYPO3's autoload feature works differently
-in composer based installations, you have to register your PHP class
-names in composer. This is very easy when you use PHP namespaces:
+in Composer based installations, you have to register your PHP class
+names in Composer. This is very easy when you use PHP namespaces:
 
 .. code-block:: json
 
@@ -286,7 +286,7 @@ names in composer. This is very easy when you use PHP namespaces:
 
 For extension without PHP namespaces, this section has to look a bit
 differently. You can decide by yourself, if you want to list each PHP file
-manually or if composer should search for them inside a folder:
+manually or if Composer should search for them inside a folder:
 
 .. code-block:: json
 

--- a/Documentation/MigrateToComposer/Requirements.rst
+++ b/Documentation/MigrateToComposer/Requirements.rst
@@ -15,16 +15,15 @@ be found down to version 6.2.0:
 Composer
 ========
 
-Of course, you need ``composer``. It's a program, written in PHP.
-Because you already use TYPO3, you should know how to install PHP.
-Instructions how to download and install ``composer`` can be found on
+Of course, you need Composer. It's a program, written in PHP.
+Instructions how to download and install Ccomposer can be found on
 `getcomposer.org <https://getcomposer.org>`__.
 
 Folder structure
 ================
 
 If your project root folder is identical to your web root folder, you
-must change that. ``composer`` will add a :file:`vendor` folder to your project
+must change that. Composer will add a :file:`vendor` folder to your project
 root and if your project root and your web root are identical, this can
 be a security issue, because files in the :file:`vendor` could be accessible
 directly via HTTP request.
@@ -61,7 +60,7 @@ If you do not have such a web root directory, you must refactor your
 project before continuing. Please be aware to tell your web server
 about the changed web root folder, if necessary.
 
-Code integrity
+Code Integrity
 ==============
 
 Your project must have the TYPO3 core and all installed extensions in
@@ -70,8 +69,8 @@ be lost during the migration steps.
 
 .. note ::
 
-    If you need to apply hotfixes or patches to the TYPO3 core or public
-    available extensions, this `tutorial about applying patches via composer
+    If you need to apply hotfixes or patches to the TYPO3 core or publicly
+    available extensions, this `tutorial about applying patches via Composer
     <https://typo3worx.eu/2017/08/patch-typo3-using-composer/>`__ could help,
     but requires some advanced steps.
 

--- a/Documentation/QuickInstall/Composer/Index.rst
+++ b/Documentation/QuickInstall/Composer/Index.rst
@@ -10,7 +10,7 @@ Install TYPO3 via composer
 
 .. attention::
 
-   The recommended way of installing TYPO3 is via composer, as described on
+   The recommended way of installing TYPO3 is via Composer, as described on
    this page.
 
 
@@ -21,11 +21,11 @@ To create a new TYPO3 project use the TYPO3 Base Distribution::
 
 .. note::
 
-   To install TYPO3 via composer on windows composer should be started as admin
+   To install TYPO3 via the `composer` command on windows, it should be started as admin
    or explicitly given the right to create symlinks (use for example a
    powershell or git bash started with admin rights).
 
-After composer finishes, you should have the following folder structure:
+After `composer create project ...` executed, you should have the following folder structure:
 
 .. figure:: ../../Images/folder-structure-composer.png
    :class: with-shadow
@@ -36,9 +36,7 @@ After composer finishes, you should have the following folder structure:
 
 Point the document root of your web server to the `public` folder.
 
-After composer installation continue with the steps in :ref:`the-install-tool`
-
-If you do not want to use composer, follow the :ref:`package installation
+If you do not want to use Composer, follow the :ref:`package installation
 guide <get-and-unpack-the-typo3-package>`.
 
 Next Steps

--- a/Documentation/QuickInstall/GetAndUnpack/Index.rst
+++ b/Documentation/QuickInstall/GetAndUnpack/Index.rst
@@ -9,12 +9,12 @@ Get and Unpack the TYPO3 Package
 
 .. attention::
 
-   This is an alternative method of installation to composer installation.
-   The recommended way of installing TYPO3 is :ref:`via composer <install-via-composer>`.
+   The recommended way of installing TYPO3 is :ref:`via Composer <install-via-composer>`.
+   This page describes an alternative method of installing TYPO3 without Composer.
 
 .. _installation-unix:
 
-Installing on a Unix server
+Installing on a Unix Server
 ===========================
 
 #. Get the Source Package from `http://typo3.org/download/
@@ -78,7 +78,7 @@ a new patchlevel version of TYPO3 is released.
 
 .. _installation-windows:
 
-Installing on a Windows server
+Installing on a Windows Server
 ==============================
 
 #. Get the Source Package from `http://typo3.org/download/


### PR DESCRIPTION
- apply title case (capitalize most words as defined in TYPO3 Content Style Guide)
- use spelling 'Composer' unless explicitly referring to command 'composer'.
  In the latter case use inline code (backticks).