### PR TITLE
Update required version number

### DIFF
--- a/Documentation/QuickInstall/Index.rst
+++ b/Documentation/QuickInstall/Index.rst
@@ -16,7 +16,7 @@ machine (which needs elevated permissions on Windows machines).
 Pre-Requisites:
 
 * Running web server (Apache, Nginx, IIS...)
-* PHP > 7.2 installed
+* PHP ≥ 7.2 installed
 
 
 .. toctree::


### PR DESCRIPTION
TYPO3 v9 requires PHP 7.2 or later.