### PR TITLE
Rename chapter for installing without composer

### DIFF
--- a/Documentation/QuickInstall/GetAndUnpack/Index.rst
+++ b/Documentation/QuickInstall/GetAndUnpack/Index.rst
@@ -2,10 +2,11 @@
 .. highlight:: shell
 
 .. _get-and-unpack-the-typo3-package:
+.. _install-typo3-without-composer:
 
-================================
-Get and Unpack the TYPO3 Package
-================================
+==============================
+Install TYPO3 Without Composer
+==============================
 
 .. attention::
 


### PR DESCRIPTION
A renaming makes it clearer that with / without composer are two
alternate installation methods and not steps to be executed one
after the other.