### PR TITLE
Move sitemap to the end

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -73,11 +73,11 @@ given task.
 .. toctree::
    :titlesonly:
 
-   Sitemap/Index
    Introduction/Index
    QuickInstall/Index
    In-depth/Index
    Upgrade/Index
    MigrateToComposer/Index
    Troubleshooting/Index
+   Sitemap/Index
    Linktargets/Index


### PR DESCRIPTION
- Since a sitemap is already on the start page, people had to page
  through 2 sitemaps
- In general, we move sitemap to the end