### PR TITLE
Add additional section for patch updates

### DIFF
--- a/Documentation/Composer/Index.rst
+++ b/Documentation/Composer/Index.rst
@@ -52,6 +52,9 @@ with the package name. You should always add
 ``--with-all-dependencies`` attribute to also update the required third
 party packages.
 
+
+.. _update-typo3-core-with-composer:
+
 Update TYPO3 Core
 ~~~~~~~~~~~~~~~~~
 
@@ -62,6 +65,8 @@ Without "subtree split"::
 With "subtree split"::
 
     composer update typo3/cms-* --with-all-dependencies
+
+.. _update-exensions-with-composer:
 
 Update Extensions Like "news"
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -107,6 +112,9 @@ control system.
     Please be sure to disable extensions in TYPO3's Extension Manager, before removing them with `composer`.
     Or ensure to regenerate your :file:`typo3conf/PackageStates.php` file automatically, after removing the packages. You could use the
     `extension "typo3_console" <https://docs.typo3.org/typo3cms/extensions/typo3_console/CommandReference/Index.html#install-generatepackagestates>`__ for that
+
+
+.. _composer-check-for-available-updates:
 
 Check for Available Updates
 ===========================

--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -81,6 +81,7 @@ a GNU/GPL CMS/Framework available from `www.typo3.org
    In-depth/Index
    Composer/Index
    ExtensionInstallation/Index
+   Update/Index
    Upgrade/Index
    MigrateToComposer/Index
    Troubleshooting/Index

--- a/Documentation/Update/Index.rst
+++ b/Documentation/Update/Index.rst
@@ -1,0 +1,104 @@
+.. include:: ../Includes.txt
+
+.. highlight:: bash
+
+.. _update:
+
+==================
+TYPO3 Patch Update
+==================
+
+
+Updating major and minor versions is handled in :ref:`upgrade`. A major update
+requires running the Upgrade Wizards and database analyzer, as well as other
+procedures.
+
+An update to a TYPO3 version with only a higher patch number does not require
+the extensive handling of a major update. The patch update is handled here.
+
+.. important::
+
+   Always check the release notes for the version you are updating to.
+   Some updates may require additional steps.
+
+Because most of the steps are already documented elsewhere, we simply show
+a quick summary and provide links to the sections where the steps are explained
+in detail.
+
+.. tip::
+
+   You may want to optimize your update procedure or for example add a
+   deployment toolchain (see :ref:`composer-best-practice-deployment`).
+   Here, we only show the most basic steps.
+
+
+
+Go to https://get.typo3.org and select your version, click on "Release
+Notes".
+
+.. _update-with-composer:
+
+Steps for Patch Update With Composer
+------------------------------------
+
+To check for available updates, do::
+
+   composer outdated
+
+
+See :ref:`composer-check-for-available-updates`
+
+
+.. rst-class:: bignums
+
+
+1. Update TYPO3 core
+
+   .. code-block:: bash
+
+      composer update typo3/cms-* --with-all-dependencies
+
+   See :ref:`update-typo3-core-with-composer`
+
+2. Run DB Analyzer
+
+   In case the release notes indicated database changes (this is usually
+   not the case), :ref:`run the DB analyzer <run-the-database-analyzer>`.
+
+3. Update Extensions
+
+   See :ref:`update-exensions-with-composer`
+
+4. Clear cache
+
+   See :ref:`clear-cache`
+
+
+.. _update-without-composer:
+
+Steps for Patch Update Without Composer
+---------------------------------------
+
+
+.. rst-class:: bignums
+
+
+1. Update TYPO3 core
+
+
+   Download and extract the archive, replace the symbolic link:
+
+   See :ref:`install-manually`
+
+2. Run DB Analyzer
+
+   In case the release notes indicated database changes (this is usually
+   not the case), :ref:`run the DB analyzer <run-the-database-analyzer>`.
+
+3. Update Extensions
+
+   See :ref:`update-extensions-without-composer`
+
+4. Clear cache
+
+   See :ref:`clear-cache`

--- a/Documentation/Update/Index.rst
+++ b/Documentation/Update/Index.rst
@@ -28,7 +28,7 @@ in detail.
 .. tip::
 
    You may want to optimize your update procedure or for example add a
-   deployment toolchain (see :ref:`composer-best-practice-deployment`).
+   deployment toolchain.
    Here, we only show the most basic steps.
 
 

--- a/Documentation/Upgrade/Index.rst
+++ b/Documentation/Upgrade/Index.rst
@@ -1,16 +1,26 @@
+﻿.. ==================================================
+.. FOR YOUR INFORMATION
+.. --------------------------------------------------
+.. -*- coding: utf-8 -*- with BOM.
+
 .. include:: ../Includes.txt
 
 
 .. _upgrade:
 
-Upgrade
-=======
+===================
+Major TYPO3 Upgrade
+===================
+
+This section handles major TYPO3 updates. For patch updates (e.g. 9.5.2
+to 9.5.3), please see the chapter :ref:`update`.
 
 When a new version of TYPO3 is released, you should follow the
 guideline in this chapter in order to do an upgrade. Also follow any
 additional upgrade information carefully. You might e.g. want to skim
-the `Release Notes <https://get.typo3.org/release-notes>`_ to
-see if any features affect the way your site works.
+the included ChangeLog to see if any features affect the way your site
+works. (Look for lines prepended with "!!!" - those are the really
+important ones!)
 
 .. note::
 
@@ -35,7 +45,6 @@ Basically these are the steps to be done to update your TYPO3 site:
    :titlesonly:
    :glob:
 
-   Preparation/Index
    Backup/Index
    UpdateReferenceIndex/Index
    InstallTheNewSource/Index

--- a/Documentation/Upgrade/RemoveTemporaryCacheFiles/Index.rst
+++ b/Documentation/Upgrade/RemoveTemporaryCacheFiles/Index.rst
@@ -2,6 +2,7 @@
 
 
 .. _remove-temporary-cache-files:
+.. _clear-cache:
 
 ============
 Clear Caches

--- a/Documentation/Upgrade/UpdateExtensions/Index.rst
+++ b/Documentation/Upgrade/UpdateExtensions/Index.rst
@@ -2,6 +2,7 @@
 
 
 .. _update-extensions:
+.. _update-extensions-without-composer:
 
 ==============================================
 Update Extensions (non-Composer Installations)


### PR DESCRIPTION
Currently, there is only one chapter "Upgrade" with handles TYPO3 updates but contains
several steps that are only necessary for major updates.

This patch adds an additional chapter "patch updates" and some clarifications about
the version numbers.