### PR TITLE
Add official TYPO3 video tutorial link to composer installation guide

### DIFF
--- a/Documentation/QuickInstall/Composer/Index.rst
+++ b/Documentation/QuickInstall/Composer/Index.rst
@@ -44,6 +44,11 @@ Point the document root of your web server to the `public` folder.
 If you do not want to use Composer, follow the :ref:`package installation
 guide <get-and-unpack-the-typo3-package>`.
 
+See also
+========
+
+* `Tutorial - Quick TYPO3 Installation with Composer <https://www.youtube.com/watch?v=M4imQOUKDe4>`_ from the official TYPO3 YouTube channel
+
 Next Steps
 ==========
 

--- a/Documentation/QuickInstall/Composer/Index.rst
+++ b/Documentation/QuickInstall/Composer/Index.rst
@@ -44,10 +44,10 @@ Point the document root of your web server to the `public` folder.
 If you do not want to use Composer, follow the :ref:`package installation
 guide <get-and-unpack-the-typo3-package>`.
 
-See also
-========
+Tutorial from the official TYPO3 YouTube channel
+================================================
 
-* `Tutorial - Quick TYPO3 Installation with Composer <https://www.youtube.com/watch?v=M4imQOUKDe4>`_ from the official TYPO3 YouTube channel
+.. youtube:: M4imQOUKDe4
 
 Next Steps
 ==========


### PR DESCRIPTION
Just a rather small change! I wanted to merge together content from the Wiki page handling the same topic (https://wiki.typo3.org/ComposerInstallation), so we can just provide a link to the docs version to clear some _duplicated_ content.

And I think the official TYPO3 video on the subject is a fair inclusion.