### PR TITLE
Fix TYPO3 version; add warning for mac users

### DIFF
--- a/Documentation/In-depth/SystemRequirements/Index.rst
+++ b/Documentation/In-depth/SystemRequirements/Index.rst
@@ -134,8 +134,11 @@ are available.
   * sqlsrv (if you use SQL Server as DBMS)
   * sqlite (if you use SQLite as DBMS)
 
-..warning::
+.. warning::
 
-  * Mac-Users: On macOS 10.13.6 and probably also 10.14.* (unconfirmed) pcre causes troubles, with brew as well as native or MAMP installations. It is recommended to use php 7.2. More info can be found here:
-    `Not working after upgrading to 7.3 <https://github.com/bobthecow/psysh/issues/540>`_
-    `Bug #77260	preg_match_all(): JIT compilation failed: no more memory <https://bugs.php.net/bug.php?id=77260>`_
+    With **PHP 7.3** in combination with **macOS** 10.13.6 (and probably also 10.14 - unconfirmed)
+    pcre causes problems with brew as well as native or MAMP installations. It is
+    recommended to use PHP 7.2. More information can be found here:
+
+    * `Not working after upgrading to 7.3 <https://github.com/bobthecow/psysh/issues/540>`_
+    * `Bug #77260	preg_match_all(): JIT compilation failed: no more memory <https://bugs.php.net/bug.php?id=77260>`_

--- a/Documentation/In-depth/SystemRequirements/Index.rst
+++ b/Documentation/In-depth/SystemRequirements/Index.rst
@@ -11,7 +11,7 @@ TYPO3 requires a web server, PHP and a database system.
 
 * TYPO3 requires a web server which can run PHP (e.g. Apache, Nginx or IIS).
 
-* TYPO3 9 requires at least PHP 7.2.x
+* TYPO3 10 requires at least PHP 7.2.x (Mac users: see warning a the end of this document)
 
 * TYPO3 can be used with a great many database systems (e.g. MySQL or
   Postgres). If you use MySQL, you will need to install at least MySQL 5.5. and maximum MySQL 5.7
@@ -112,7 +112,7 @@ are available.
 
   * PDO
   * json
-  * pcre >= 8.38
+  * pcre >= 8.38 (Mac users: see warning a the end of this document)
   * session
   * xml
   * filter
@@ -133,3 +133,9 @@ are available.
   * postgresql (if you use PostgreSQL as DBMS)
   * sqlsrv (if you use SQL Server as DBMS)
   * sqlite (if you use SQLite as DBMS)
+
+..warning::
+
+  * Mac-Users: On macOS 10.13.6 and probably also 10.14.* (unconfirmed) pcre causes troubles, with brew as well as native or MAMP installations. It is recommended to use php 7.2. More info can be found here:
+    `Not working after upgrading to 7.3 <https://github.com/bobthecow/psysh/issues/540>`_
+    `Bug #77260	preg_match_all(): JIT compilation failed: no more memory <https://bugs.php.net/bug.php?id=77260>`_


### PR DESCRIPTION
Mention TYPO3 v10 instead of v9.

On Mac, php 7.3 causes troubles because prce. In order to help users to save some headaches, this problem is mentioned here already.