### PR TITLE
add aditional step to migrating to composer

### DIFF
--- a/Documentation/MigrateToComposer/MigrationSteps.rst
+++ b/Documentation/MigrateToComposer/MigrationSteps.rst
@@ -330,7 +330,7 @@ To complete our example :file:`composer.json`, it would look like this:
         }
     }
     
-After adding files to the autoload you should run `composer dumpautoload`. This command will re-generate the vendor/autoload.php file
+After adding paths to the autoload you should run `composer dumpautoload`. This command will re-generate the autoload info and should be run anytime you add new paths to the autoload portion in the composer.json
 
 .. note::
 

--- a/Documentation/MigrateToComposer/MigrationSteps.rst
+++ b/Documentation/MigrateToComposer/MigrationSteps.rst
@@ -330,7 +330,7 @@ To complete our example :file:`composer.json`, it would look like this:
         }
     }
     
-After adding paths to the autoload you should run `composer dumpautoload`. This command will re-generate the autoload info and should be run anytime you add new paths to the autoload portion in the composer.json
+After adding paths to the autoload you should run `composer dumpautoload`. This command will re-generate the autoload info and should be run anytime you add new paths to the autoload portion in the :file:`composer.json`.
 
 .. note::
 

--- a/Documentation/MigrateToComposer/MigrationSteps.rst
+++ b/Documentation/MigrateToComposer/MigrationSteps.rst
@@ -329,6 +329,8 @@ To complete our example :file:`composer.json`, it would look like this:
             ]
         }
     }
+    
+After adding files to the autoload you should run `composer dumpautoload`. This command will re-generate the vendor/autoload.php file
 
 .. note::
 


### PR DESCRIPTION
If this step is not done from a created project, you will get error #1278450972. You must run `composer dumpautoload` for the project to run with the extensions you are keeping in the ext directory