### PR TITLE
Mention official introduction package install in QuickInstall

### DIFF
--- a/Documentation/QuickInstall/TheInstallTool/Index.rst
+++ b/Documentation/QuickInstall/TheInstallTool/Index.rst
@@ -79,7 +79,28 @@ The Install Tool
       :class: with-shadow
 
       Install Tool in 1-2-3 mode, fifth step.
+      
+   **Introduction distribution**
+   
+   If you are new to TYPO3 you might want to start with example pages and 
+   content added. The `official Introduction Package 
+   <https://extensions.typo3.org/extension/introduction/>`__ showcases TYPO3s 
+   capabilities and gives you a head start to play around with a functioning 
+   site. It uses the `extension bootstrap_package
+   <https://extensions.typo3.org/extension/bootstrap_package/>`__ which 
+   uses the Bootstrap CSS framework and adds custom content elements to make
+   use of it within TYPO3. 
+   
+   #. **If you installed TYPO3 with composer**
+      
+      You have to `add a composer package and enable the extension
+      <https://docs.typo3.org/typo3cms/extensions/introduction/stable/Installation.html>`__.
 
+   #. **If you installed TYPO3 without composer**
+   
+      You can select "Yes, download the list of distributions" here. 
+      On first backend login, you will be redirected to a page where you can 
+      install the "Official introduction package" with one click.
 
 #. **The basic installation is now complete!**
 

--- a/Documentation/QuickInstall/TheInstallTool/Index.rst
+++ b/Documentation/QuickInstall/TheInstallTool/Index.rst
@@ -82,25 +82,33 @@ The Install Tool
       
    **Introduction distribution**
    
-   If you are new to TYPO3 you might want to start with example pages and 
-   content added. The `official Introduction Package 
-   <https://extensions.typo3.org/extension/introduction/>`__ showcases TYPO3s 
-   capabilities and gives you a head start to play around with a functioning 
-   site. It uses the `extension bootstrap_package
-   <https://extensions.typo3.org/extension/bootstrap_package/>`__ which 
-   uses the Bootstrap CSS framework and adds custom content elements to make
-   use of it within TYPO3. 
+   If you are using TYPO3 for the first time you may want to
+   see a working example of the CMS before you start work on
+   your own project.
+   The `Official Introduction Package
+   <https://extensions.typo3.org/extension/introduction/>`__ showcases many of 
+   TYPO3's capabilities and gives you the ability to try them first hand.
+   The Introduction Package utilizes the `bootstrap_package extension
+   <https://extensions.typo3.org/extension/bootstrap_package/>`__
+   to generate multiple responsive HTML templates that you can select and try
+   out.
+   It also features examples of the different kinds page content that you 
+   typically see on a website. Such as paragraphs of text, images, tables 
+   and navigation menus.
    
    #. **If you installed TYPO3 with composer**
       
-      You have to `add a composer package and enable the extension
+      You will need to `add the composer package and enable the extension in 
+      the backend of the CMS
       <https://docs.typo3.org/typo3cms/extensions/introduction/stable/Installation.html>`__.
 
    #. **If you installed TYPO3 without composer**
    
-      You can select "Yes, download the list of distributions" here. 
-      On first backend login, you will be redirected to a page where you can 
-      install the "Official introduction package" with one click.
+      You can select "Yes, download the list of distributions" when you finish 
+      installing the CMS.
+      Then, when you log in to the backend for the first time, you will be 
+      presented with a list of available packages including the "Official 
+      Introduction Package".
 
 #. **The basic installation is now complete!**
 


### PR DESCRIPTION
The TYPO3 official introduction package is a great possibility for new users to look around and experience TYPO3. It would market TYPO3 a lot better than the "empty start page". I suggest to add it to the QuickInstall manual. in my opinion this will add value for newcomers. Unfortunatley with composer this possiblity has become a lot less obvious (See also https://forge.typo3.org/issues/88940) why IMHO we need to mention it here.