### PR TITLE
Add info about composer outdated command with direct option

### DIFF
--- a/Documentation/Composer/Index.rst
+++ b/Documentation/Composer/Index.rst
@@ -118,6 +118,7 @@ Check for Available Updates
 
 Run `composer outdated` to see a list of available updates.
 
+Run `composer outdated -D` to see a list available updates for directly required packages.
 
 Useful Packages and Bundles
 ===========================


### PR DESCRIPTION
You get a better overview of installed extensions and the core
if you don't see required packages by TYPO3 core or 3rd-party
TYPO3 extensions.