### PR TITLE
Improve Upgrade preparation page

### DIFF
--- a/Documentation/Settings.cfg
+++ b/Documentation/Settings.cfg
@@ -55,5 +55,6 @@ project_repository   = https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-Ins
 ; Uncomment only what you actually use in crossreferencing!
 
 h2document    = https://docs.typo3.org/m/typo3/docs-how-to-document/master/en-us/
+t3core        = https://docs.typo3.org/c/typo3/cms-core/master/en-us/
 t3coreapi     = https://docs.typo3.org/m/typo3/reference-coreapi/master/en-us/
 

--- a/Documentation/Upgrade/ChangelogAndNewsmd/Index.rst
+++ b/Documentation/Upgrade/ChangelogAndNewsmd/Index.rst
@@ -1,7 +1,7 @@
-﻿.. include:: ../../Includes.txt
+﻿:orphan:
 
 
-.. _check-the-changelog-and-news-md:
+The content of this page was moved to :ref:`check-the-changelog-and-news-md`.
 
 ===================
 Check the ChangeLog
@@ -18,8 +18,3 @@ whether or not your website is affected by the change.
 You can also find the ChangeLog in the Install Tool at "Upgrade Analysis". Here you can mark files
 as read after checking them, so you get a ToDo list for the upgrade.
 
-.. figure:: ../../Images/Upgrade-Analysis.png
-   :class: with-shadow
-   :alt: Uprade Analysis
-
-   The "Upgrade Analysis" in the Install Tool

--- a/Documentation/Upgrade/Preparation/Index.rst
+++ b/Documentation/Upgrade/Preparation/Index.rst
@@ -2,27 +2,37 @@
 
 
 .. _preparation:
+.. _beforeUpgrading:
 
-===========
-Preparation
-===========
-
-
-Before You Start
 ================
+Before upgrading
+================
+
+* You should use the latest version of a previous major version before you upgrade!
+  For example, upgrade to latest 9.5.x before you upgrade to version 10.
 
 Before starting the upgrade check your system for compatibility with a newer
 TYPO3 version.
 
-*  Enable the deprecation log and let it run for a while while the website is
-   used to catch all deprecations
+* Before you upgrade to the next major version, make sure you have run all
+  Upgrade Wizards of the the current TYPO3 major version.
 
-*  Check installed extensions for versions compatible to the target TYPO3
-   version
+* Check for deprecations: Enable the deprecation log and let it log all
+  deprecations for a while.
 
-*  Try the upgrade on a development system first or create a parallel instance
+* Alternatively (or additionally) run the
+  :ref:`extension scanner <t3coreapi:extension-scanner>` and
+  :ref:`handle deprecations <handling-deprecations>` (below).
 
-*  Run the extension scanner (see below)
+* Check installed extensions for versions compatible to the target TYPO3
+  version
+
+* Try the upgrade on a development system first or create a parallel instance
+
+
+Check that all system requirements for upgrading are met:
+
+* See :ref:`system-requirements`
 
 .. _handling-deprecations:
 
@@ -30,17 +40,19 @@ Handling Deprecations
 =====================
 
 If you notice some API you are using is deprecated, you should look up the
-corresponding `ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/>`_
+corresponding `ChangeLog <https://docs.typo3.org/c/typo3/cms-core/master/en-us/>`_
 entry and see how to migrate your code corresponding to the documentation.
 
-Since TYPO3 v9 an extension scanner is included, that provides basic scanning
-of your extensions for deprecated code. While it does not catch everything, it
-can be used as a base for an upgrade. You can either access the extension
-scanner via the TYPO3 admin tools (Backend > Module "Upgrade" > "Scan Extension
-Files") or as a standalone tool (https://github.com/tuurlijk/typo3scan)
+Since TYPO3 v9 an :ref:`extension scanner <t3coreapi:extension-scanner>` is
+included, that provides basic scanning of your extensions for deprecated code.
+While it does not catch everything, it can be used as a base for an upgrade. You
+can either access the extension scanner via the TYPO3 admin tools (in the
+Backend: :guilabel:`Module "Upgrade" > "Scan Extension Files"`)
+or as a standalone tool (https://github.com/tuurlijk/typo3scan).
 
-Read where to find deprecation documentation in the chapter about
-:ref:`check-the-changelog-and-news-md`.
+The extension scanner will show the corresponding changelog which contains
+a description of how to migrate your code. See :ref:`check-the-changelog-and-news-md`
+for more information about the Changelogs and how to read them.
 
 .. note::
 
@@ -62,3 +74,40 @@ Read where to find deprecation documentation in the chapter about
    This strategy gives developers sufficient time to adjust their TYPO3
    extensions, assuming many agencies upgrade from one LTS release to the next
    (usually 1.5 years).
+
+.. _check-the-changelog-and-news-md:
+
+Check the ChangeLog
+===================
+
+In addition to the deprecations you may want to read the information about important
+changes, new features and breaking changes for the release you are updating to.
+
+The ChangeLog is divided into four sections "Breaking Changes", "Features", "Deprecation" and
+"Important". Before upgrading you should at least take a look at the sections "Breaking Changes"
+and "Important" - changes described in those areas might affect your website.
+
+.. tip::
+
+   Breaking changes should be of no concern to you if you already handled the
+   deprecations before upgrading.
+
+The detailed information contains a section called "Affected Installations" which contains hints
+whether or not your website is affected by the change.
+
+There are 3 different methods you can use to read the Changelogs:
+
+#. Look through the `ChangeLogs <https://docs.typo3.org/typo3cms/extensions/core/>`_
+   online. This has the advantage that code blocks will be formatted nicely with
+   syntax highlighting.
+#. Read the Changelogs in the backend: :guilabel:`Upgrade > View Upgrade Documentation`.
+   This has the advantage that you can filter by tags and mark individual Changelogs
+   as done. This way, it is possible to use the list like a todo list.
+#. Read the changelog in the :ref:`Extension Scanner <t3coreapi:extension-scanner>`
+   (as explained above).
+
+.. figure:: ../../Images/Upgrade-Analysis.png
+   :class: with-shadow
+   :alt: Uprade Analysis
+
+   The "Upgrade Analysis" in the Install Tool


### PR DESCRIPTION
- Merge page about changelogs to preparation page because this should be done
  before updating (it even says "Before upgrading you should at least take a
  look at the sections ..."). The "Preparation" page contains information about
  what to do before updating. More importantly, it already contains related
  information like information on extension scanner and deprecations.
- Rename the page "Preparation" to "Before Upgrading" because that is
  clearer.
- Add some links (e.g. to extension scanner page)
- Add the 3 methods to read changelogs with their individual advantages.

Related: #142