### PR TITLE
[TASK] Drop CE anchor

### DIFF
--- a/Documentation/Introduction/Index.rst
+++ b/Documentation/Introduction/Index.rst
@@ -70,4 +70,4 @@ Contact the Documentation Team
 ==============================
 
 For general questions about the documentation get in touch with
-the `Documentation Team <https://typo3.org/community/teams/documentation/#c9886>`__.
+the `Documentation Team <https://typo3.org/community/teams/documentation/>`__.


### PR DESCRIPTION
We should not link to specific content elements by their UID since they are bound to change over time.

Discovered in https://github.com/TYPO3-Documentation/TYPO3CMS-Tutorial-Editors/pull/21