### PR TITLE
Clarify chapter "Which package and which format"

### DIFF
--- a/Documentation/In-depth/WhichPackageAndFormat/Index.rst
+++ b/Documentation/In-depth/WhichPackageAndFormat/Index.rst
@@ -2,22 +2,38 @@
 
 .. _which-package-and-which-file-format:
 
-===============================
-Which Package and Which Format?
-===============================
+=========================
+With Composer or without?
+=========================
+
+With Composer
+=============
 
 The recommended way of installing TYPO3 is via the PHP package manager `Composer`.
-For detailed instructions on how to install TYPO3 using Composer, visit the
+For detailed instructions on how to install TYPO3 **with** Composer, visit the
 :ref:`install-via-composer` section of this manual.
 
+When you install with Composer, you will install the core extensions and third
+party extensions with the package manager Composer on the command line. You will
+not be able to import extensions (e.g. from TER) in the TYPO3 backend via the browser!
+
+Without Composer
+================
+
 If you do not have access to Composer, you can install TYPO3 by downloading
-and then extracting its source package on your web server. TYPO3's source package
-can be found here: `https://get.typo3.org <https://get.typo3.org/version/10>`_.
+and then extracting its source package on your web server.
+
+Directions for installing TYPO3 **without** Composer can be found in
+:ref:`install-typo3-without-composer`.
 
 .. _which-file-format-to-use:
 
 Which File Format to Use
-========================
+------------------------
+
+.. tip::
+
+   This is only relevant if you install TYPO3 **without** Composer!
 
 The TYPO3 Source package is available as a :file:`.zip` or
 :file:`.tar.gz` distribution. Their content is the same and you should


### PR DESCRIPTION
- Add Composer to title. The title "Which Package and which format" was used in older
  versions of this manual, when there are several packages - currently this
  is no longer relevant. Having Composer in the title fits better with the
  content
- Add headers to separate the parts about with Composer from without Composer
- We already have a page for installing without Composer. Link to that