### PR TITLE
Give overview over installation steps in quick install

### DIFF
--- a/Documentation/QuickInstall/Index.rst
+++ b/Documentation/QuickInstall/Index.rst
@@ -13,17 +13,40 @@ section :ref:`in-depth-installation`.
 The following instructions assume you are able to create symlinks on the target
 machine (which needs elevated permissions on Windows machines).
 
-**Pre-Requisites:**
+**Installation steps:**
 
-* Running web server (Apache, Nginx, IIS...)
-* PHP ≥ 7.2 installed
-* ... more see :ref:`system-requirements`
+.. rst-class:: bignums-xxl
 
+1. Checkout out the system requirements
 
-**Table of contents:**
+   Install required software, such as:
+
+   * Web server (Apache, Nginx, IIS...)
+   * PHP ≥ 7.2
+   * Database server (MySQL, PostgreSQL, MariaDB ...)
+   * ... more see :ref:`system-requirements`
+
+2. Install the TYPO3 core
+
+   This can be done either using the package manager Composer or by unpacking
+   a downloaded archive. Using Composer is the recommended way to install TYPO3.
+
+   The installation steps are described in the subchapters:
+
+   * :ref:`install-via-composer`
+   * **or** :ref:`install-typo3-without-composer`
+
+3. "Admin Tool"
+
+   Once the source is installed, you must walk through the "Admin Tool" (formerly called
+   "Install Tool"). This is described in:
+
+   * :ref:`the-install-tool`
+
 
 .. toctree::
    :titlesonly:
+   :hidden:
 
    Composer/Index
    GetAndUnpack/Index


### PR DESCRIPTION
Before the change, we had 3 subchapters listed on start page, without
much context or explanation:

* Install with composer
* Install without composer
* Install tool

The first 2 points are mutually exclusive, the third point must be
executed in any case.

This change tries to give the user a better overview of the various
installation steps.