### PR TITLE
Update documentation about IIS config

### DIFF
--- a/Documentation/In-depth/SystemRequirements/Index.rst
+++ b/Documentation/In-depth/SystemRequirements/Index.rst
@@ -134,6 +134,8 @@ Microsoft Internet Information Services (IIS)
 
 * Default IIS web config file with rewrite rules can be found in
   :file:`EXT:install/Resources/Private/FolderStructureTemplateFiles/root-web-config`
+  
+* Make sure that the `URL Rewrite plugin <https://www.iis.net/downloads/microsoft/url-rewrite>`__ is installed on your system.  
 
 NGINX
 -----


### PR DESCRIPTION
Added information on IIS config: in order to use speaking url, the url-rewrite plugin should be already present on IIS - see the issue https://forge.typo3.org/issues/92058

Please review.