### PR TITLE
Fix error at composer command

### DIFF
--- a/Documentation/QuickInstall/Composer/Index.rst
+++ b/Documentation/QuickInstall/Composer/Index.rst
@@ -17,7 +17,7 @@ Install TYPO3 via composer
 To create a new TYPO3 project use the TYPO3 Base Distribution::
 
    # Download the Base Distribution, the latest "stable" release (9.5)
-   composer create-project typo3/cms-base-distribution:^9 YourNewProjectFolder
+   composer create-project typo3/cms-base-distribution:"^9" YourNewProjectFolder
 
 .. note::
 


### PR DESCRIPTION
When using the command I got the error: "zsh: no matches found: typo3/cms-base-distribution:^9". I think it is safer to have the version constraint inside quotes.