### PR TITLE
Rename installation chapters

### DIFF
--- a/Documentation/In-depth/Index.rst
+++ b/Documentation/In-depth/Index.rst
@@ -3,8 +3,9 @@
 
 .. _in-depth-installation:
 
-In-Depth Installation
----------------------
+======================
+Installation explained
+======================
 
 
 .. toctree::

--- a/Documentation/QuickInstall/Index.rst
+++ b/Documentation/QuickInstall/Index.rst
@@ -3,7 +3,7 @@
 .. _quick-installation:
 
 ==================
-Quick Installation
+Installation steps
 ==================
 
 For those already familiar with running web software, get started quickly with
@@ -12,8 +12,6 @@ section :ref:`in-depth-installation`.
 
 The following instructions assume you are able to create symlinks on the target
 machine (which needs elevated permissions on Windows machines).
-
-**Installation steps:**
 
 .. rst-class:: bignums-xxl
 

--- a/Documentation/QuickInstall/Index.rst
+++ b/Documentation/QuickInstall/Index.rst
@@ -2,9 +2,9 @@
 
 .. _quick-installation:
 
-==================
-Installation steps
-==================
+================
+Installing TYPO3
+================
 
 For those already familiar with running web software, get started quickly with
 this quick install guide. For a more detailed description, take a look at the


### PR DESCRIPTION
- "Quick installation" -> "Installation steps"
- "In-Depth installation" -> "Installation explained"

This makes it more clearer to me why there are 2 chapters. At the beginning I had expected to find a short walkthrough in "Quick installation" and a longer more detailed walkthrough in "In-Depth". But, "In-Depth" is not really a walkthrough at all. You should start with the Installation steps in any case. "In depth" just contains some further explanations. 

I hope, this change makes this more clear.