### PR TITLE
Add DDEV to quick installation

### DIFF
--- a/Documentation/QuickInstall/Index.rst
+++ b/Documentation/QuickInstall/Index.rst
@@ -26,6 +26,11 @@ machine (which needs elevated permissions on Windows machines).
    * Database server (MySQL, PostgreSQL, MariaDB ...)
    * ... more see :ref:`system-requirements`
 
+   .. tip::
+      Alternatively, you can use a container solution such as
+      `DDEV <https://www.ddev.com/get-started/>`__ which comes with preconfigured
+      configuration for TYPO3.
+
 2. Install the TYPO3 core
 
    This can be done either using the package manager Composer or by unpacking


### PR DESCRIPTION
DDEV is already mentioned on the subpage: https://docs.typo3.org/m/typo3/guide-installation/10.4/en-us/QuickInstall/Composer/Index.html#install-via-composer

> To create a new TYPO3 project using the TYPO3 Base Distribution in a ddev environment:
> # Download the Base Distribution, the latest "LTS" release (10)
> ddev composer create "typo3/cms-base-distribution:^10" --prefer-dist
