### PR TITLE
Update outdated 7.* to 9.* in version examples

### DIFF
--- a/Documentation/MigrateToComposer/MigrationSteps.rst
+++ b/Documentation/MigrateToComposer/MigrationSteps.rst
@@ -61,7 +61,7 @@ found at https://getcomposer.org/doc/articles/versions.md
 In short:
 
 *  `^9.5` or `^9.5.0` tells Composer to add newest package of
-   version 7.\* with at least 9.5.0, but not version 10.
+   version 9.\* with at least 9.5.0, but not version 10.
 
 *  `~9.5.0` tells `composer` to add the newest package of version
    9.5.\* with at least 9.5.0, but not version 9.6.


### PR DESCRIPTION
There is an old comment left, which mentions 7.* in context of version examples with TYPO3 9

Releases: master, 10.4, 9.5