### PR TITLE
Use consistent naming for public directory

### DIFF
--- a/Documentation/QuickInstall/GetAndUnpack/Index.rst
+++ b/Documentation/QuickInstall/GetAndUnpack/Index.rst
@@ -26,7 +26,7 @@ Installing on a Unix Server
    in-depth part of the manual). Use the shell to execute the following
    commands::
 
-      /var/www/site/htdocs/$ cd ..
+      /var/www/site/public/$ cd ..
       /var/www/site/$ wget --content-disposition https://get.typo3.org/10
 
 
@@ -50,7 +50,7 @@ Installing on a Unix Server
 
 #. Create these symlinks in your document root::
 
-      cd htdocs
+      cd public
       ln -s ../typo3_src-10.4.x typo3_src
       ln -s typo3_src/index.php index.php
       ln -s typo3_src/typo3 typo3
@@ -59,9 +59,9 @@ Installing on a Unix Server
 You end up with the following structure of files::
 
    typo3_src-10.4.x/
-   htdocs/typo3_src -> ../typo3_src-10.4.x/
-   htdocs/typo3 -> typo3_src/typo3/
-   htdocs/index.php -> typo3_src/index.php
+   public/typo3_src -> ../typo3_src-10.4.x/
+   public/typo3 -> typo3_src/typo3/
+   public/index.php -> typo3_src/index.php
 
 
 The advantage of this setup is that all files from the TYPO3 Source package are
@@ -93,7 +93,7 @@ Installing on a Windows Server
 
 #. Use the shell to create these symbolic links in your document root::
 
-      cd htdocs
+      cd public
       mklink /d typo3_src ..\typo3_src-10.4.x
       mklink /d typo3 typo3_src\typo3
       mklink index.php typo3_src\index.php
@@ -102,9 +102,9 @@ Installing on a Windows Server
    You end up with the following structure of files::
 
       typo3_src-10.4.x/
-      htdocs/typo3_src -> ../typo3_src-10.4.x/
-      htdocs/typo3 -> typo3_src/typo3/
-      htdocs/index.php -> typo3_src/index.php
+      public/typo3_src -> ../typo3_src-10.4.x/
+      public/typo3 -> typo3_src/typo3/
+      public/index.php -> typo3_src/index.php
 
 
 After extraction and symlink creation continue with the steps in


### PR DESCRIPTION
By default, "public" is used in Composer installations. The page
about installing TYPO3 without Composer uses "htdocs". By
changing this to "public", we already have a directory structure
that is more consistent with the one used in Composer installations.
This might make it a little more easier to migrate later.

Also, this is more consistent with the rest of the guide which uses
"public".

Resolves: #178