### PR TITLE
Add tip for referenceindex:update command

### DIFF
--- a/Documentation/Upgrade/UpdateReferenceIndex/Index.rst
+++ b/Documentation/Upgrade/UpdateReferenceIndex/Index.rst
@@ -24,6 +24,10 @@ In a non-composer installation execute::
 
    php ./typo3/sysext/core/bin/typo3 referenceindex:update
 
+.. tip::
+
+   Use `referenceindex:update 2>> /dev/null` to suppress the output of the symfony progressbar to stderr
+   (e.g. when the command is executed by a cronjob).
 
 Without Command Line
 ====================

--- a/Documentation/Upgrade/UpdateReferenceIndex/Index.rst
+++ b/Documentation/Upgrade/UpdateReferenceIndex/Index.rst
@@ -26,7 +26,7 @@ In a non-composer installation execute::
 
 .. tip::
 
-   Use `referenceindex:update 2> /dev/null` to suppress the output of the symfony progressbar to stderr
+   Use `referenceindex:update 2> /dev/null` to suppress the progress output
    (e.g. when the command is executed by a cronjob).
 
 Without Command Line

--- a/Documentation/Upgrade/UpdateReferenceIndex/Index.rst
+++ b/Documentation/Upgrade/UpdateReferenceIndex/Index.rst
@@ -26,7 +26,7 @@ In a non-composer installation execute::
 
 .. tip::
 
-   Use `referenceindex:update 2>> /dev/null` to suppress the output of the symfony progressbar to stderr
+   Use `referenceindex:update 2> /dev/null` to suppress the output of the symfony progressbar to stderr
    (e.g. when the command is executed by a cronjob).
 
 Without Command Line


### PR DESCRIPTION
Added a tip on how to suppress the output of the symfony console progressbar when executed in CLI context

Releases: master, 10.4