### PR TITLE
Remove "Check the changelog" from the menu

### DIFF
--- a/Documentation/Upgrade/ChangelogAndNewsmd/Index.rst
+++ b/Documentation/Upgrade/ChangelogAndNewsmd/Index.rst
@@ -1,20 +1,8 @@
 ﻿:orphan:
 
 
-The content of this page was moved to :ref:`check-the-changelog-and-news-md`.
-
 ===================
 Check the ChangeLog
 ===================
 
-Look through the `ChangeLog <https://docs.typo3.org/typo3cms/extensions/core/>`_ online
-The ChangeLog is divided into four sections "Breaking Changes", "Features", "Deprecation" and
-"Important". Before upgrading you should at least take a look at the sections "Breaking Changes"
-and "Important" - changes described in those areas might affect your website.
-
-The detailed information contains a section called "Affected Installations" which contains hints
-whether or not your website is affected by the change.
-
-You can also find the ChangeLog in the Install Tool at "Upgrade Analysis". Here you can mark files
-as read after checking them, so you get a ToDo list for the upgrade.
-
+The content of this page was moved to :ref:`check-the-changelog-and-news-md`.

--- a/Documentation/Upgrade/Index.rst
+++ b/Documentation/Upgrade/Index.rst
@@ -35,6 +35,5 @@ Basically these are the steps to be done to update your TYPO3 site:
    RunTheDatabaseAnalyzer/Index
    ClearCachesAndUserSettings/Index
    RemoveTemporaryCacheFiles/Index
-   ChangelogAndNewsmd/Index
    UpdateExtensions/Index
    UpdateTranslations/Index


### PR DESCRIPTION
The page ChangelogAndNewsmd/Index.rst was orphaned but not removed
from the menu.

Remove from menu and remove the text on the page (except for the
information that the content was moved).

Releases: master, 10.4