### PR TITLE
[BUGFIX] Change order for convert global extensions

### DIFF
--- a/Documentation/Upgrade/Index.rst
+++ b/Documentation/Upgrade/Index.rst
@@ -29,8 +29,8 @@ Basically these are the steps to be done to update your TYPO3 site:
    Preparation/Index
    Backup/Index
    UpdateReferenceIndex/Index
-   InstallTheNewSource/Index
    ConvertGlobalExtensions/Index
+   InstallTheNewSource/Index
    UseTheUpgradeWizard/Index
    RunTheDatabaseAnalyzer/Index
    ClearCachesAndUserSettings/Index


### PR DESCRIPTION
The upgrade wizard part should be done directly after updating the source.
Otherwise there may be problems (for example in 10.4, where entering the
backend before database schema transformations will render the backend
unusable).

Converting the extensions can be done before the upgrade process.

Resolves: #201
Releases: master, 10.4, 9.5