### PR TITLE
[BUGFIX] composer's `platform.php` should be given as whole version

### DIFF
--- a/Documentation/Composer/Index.rst
+++ b/Documentation/Composer/Index.rst
@@ -19,10 +19,8 @@ if everything worked
 fine. After running your tests, you can deploy the :file:`vendor` and
 :file:`public` folder to your web server.
 
-To avoid conflicts between your local and your server's PHP version, you
-can define your server's PHP version in your :file:`composer.json` file
-(e.g. ``{"platform": {"php": "7.2"}}``), so `composer` will always check
-the correct dependencies.
+To avoid conflicts between your local and your server's PHP version and PHP extensions, you
+can use a `composer `platform` definition<https://getcomposer.org/doc/06-config.md#platform>`__.
 
 Update Packages
 ===============

--- a/Documentation/Composer/Index.rst
+++ b/Documentation/Composer/Index.rst
@@ -20,7 +20,7 @@ fine. After running your tests, you can deploy the :file:`vendor` and
 :file:`public` folder to your web server.
 
 To avoid conflicts between your local and your server's PHP version and PHP extensions, you
-can use a `composer `platform` definition<https://getcomposer.org/doc/06-config.md#platform>`__.
+can use a Composer `platform definition <https://getcomposer.org/doc/06-config.md#platform>`__.
 
 Update Packages
 ===============


### PR DESCRIPTION
https://docs.typo3.org/m/typo3/guide-installation/master/en-us/Composer/Index.html#run-composer-locally contained an example with "7.2" only which is not recommended and should have been "7.2.32" for example. 

Since the upstream documentation contains an interesting note with implications on deployment, I chose to rather link it.