### PR TITLE
TYPO3  backend login

### DIFF
--- a/Documentation/In-depth/TheInstallTool/Index.rst
+++ b/Documentation/In-depth/TheInstallTool/Index.rst
@@ -94,6 +94,10 @@ description of the settings carefully at least once, so you get an
 impression of what you can configure. Normally you *can*, but you *don't
 have to* change anything here during installation, as the previous steps
 took care of the most important settings.
+Pay attention to use a https website and set the BE loginSecurityLevel to normal.
+On all http sites however you must set this to rsa and 
+activate the system extension rsaauth. Otherwise you will not be able to log
+into the TYPO3 backend.
 
 
 .. _upgrade-wizard:

--- a/Documentation/In-depth/TheInstallTool/Index.rst
+++ b/Documentation/In-depth/TheInstallTool/Index.rst
@@ -96,7 +96,7 @@ have to* change anything here during installation, as the previous steps
 took care of the most important settings.
 Pay attention to use HTTPS for your website and set :code:`$GLOBALS['TYPO3_CONF_VARS']['BE']['loginSecurityLevel']` to `normal`.
 On all http sites however you must set this to rsa and 
-activate the system extension rsaauth. Otherwise you will not be able to log
+activate the system extension `rsaauth`. Otherwise you will not be able to log
 into the TYPO3 backend.
 
 

--- a/Documentation/In-depth/TheInstallTool/Index.rst
+++ b/Documentation/In-depth/TheInstallTool/Index.rst
@@ -94,7 +94,7 @@ description of the settings carefully at least once, so you get an
 impression of what you can configure. Normally you *can*, but you *don't
 have to* change anything here during installation, as the previous steps
 took care of the most important settings.
-Pay attention to use a https website and set the BE loginSecurityLevel to normal.
+Pay attention to use HTTPS for your website and set :code:`$GLOBALS['TYPO3_CONF_VARS']['BE']['loginSecurityLevel']` to `normal`.
 On all http sites however you must set this to rsa and 
 activate the system extension rsaauth. Otherwise you will not be able to log
 into the TYPO3 backend.
@@ -157,4 +157,3 @@ meant to provide methods to clean up your TYPO3 installation after it
 has been running for a while. You can use it to delete cached images,
 which is helpful when you are configuring the image processing
 settings. This section is also relevant during an upgrade.
-

--- a/Documentation/In-depth/TheInstallTool/Index.rst
+++ b/Documentation/In-depth/TheInstallTool/Index.rst
@@ -95,7 +95,7 @@ impression of what you can configure. Normally you *can*, but you *don't
 have to* change anything here during installation, as the previous steps
 took care of the most important settings.
 Pay attention to use HTTPS for your website and set :code:`$GLOBALS['TYPO3_CONF_VARS']['BE']['loginSecurityLevel']` to `normal`.
-On all http sites however you must set this to rsa and 
+However, on all websites without HTTPS you should set this to `rsa` and 
 activate the system extension `rsaauth`. Otherwise you will not be able to log
 into the TYPO3 backend.
 


### PR DESCRIPTION
There is a case when no TYPO3 backend login is possible.
See TYPO3 slack typo3-cms from 1st July 2021.