### PR TITLE
[TASK] Remove "LOCK TABLE" from the permission requirements

### DIFF
--- a/Documentation/In-depth/SystemRequirements/Index.rst
+++ b/Documentation/In-depth/SystemRequirements/Index.rst
@@ -60,7 +60,7 @@ database:
 
 *  SELECT, INSERT, UPDATE, DELETE
 
-*  CREATE, DROP, INDEX, ALTER, CREATE TEMPORARY TABLES, LOCK TABLES
+*  CREATE, DROP, INDEX, ALTER, CREATE TEMPORARY TABLES
 
 It is recommended to also grant the following privileges:
 


### PR DESCRIPTION
The LOCK TABLE is not a requirement of the core and will be removed
from the PermissionChecker with this patch:

https://review.typo3.org/c/Packages/TYPO3.CMS/+/70738

The documentation should also not mention this as a requirement.