### PR TITLE
[Deprecation] #94996 - In Composer Mode, all Extensions should be ins…

### DIFF
--- a/Documentation/Composer/Index.rst
+++ b/Documentation/Composer/Index.rst
@@ -22,6 +22,19 @@ fine. After running your tests, you can deploy the :file:`vendor` and
 To avoid conflicts between your local and your server's PHP version and PHP extensions, you
 can use a Composer `platform definition <https://getcomposer.org/doc/06-config.md#platform>`__.
 
+Install extensions
+==================
+
+.. deprecated:: 11.4
+   Installing an extension in a composer-based installation by putting it
+   directly in :file:`typo3conf/ext/` is deprecated.
+
+All extensions must be installed via composer in composer-based installations.
+See :ref:`install-extension-with-composer`. Extensions that are directly in the
+projects version control like sitepackages can be installed via composer by
+keeping them in a separate directory. See
+:ref:`install-local-extension-with-composer`.
+
 Update Packages
 ===============
 

--- a/Documentation/ExtensionInstallation/Index.rst
+++ b/Documentation/ExtensionInstallation/Index.rst
@@ -179,8 +179,7 @@ with specification`.
 Install an Extension With Composer
 ==================================
 
-
-On the command line:
+Publicly available extensions can be installed with composer like this:
 
 .. rst-class:: bignums
 
@@ -217,6 +216,34 @@ On the command line:
    .. code-block:: shell
 
       ./vendor/bin/typo3 extension:activate news
+
+
+.. _install-local-extension-with-composer:
+
+Install a local extension (sitepackage, custom) with composer
+=============================================================
+
+Local extensions like site packages or custom extensions just used in
+one extension can be put in a directory like :file:`packages/example-extension`
+and then included via composer:
+
+.. code-block:: json
+
+    {
+        "repositories": [
+            {
+                "type": "path",
+                "url": "./packages/*/"
+            },
+        ],
+        "require": {
+            "my/example-extension": "@dev",
+        }
+    }
+
+When `example-extension` is located `packages/example-extension`, it is picked
+up by composer and symlinked into `typo3conf/ext/example_extension` on composer
+install.
 
 
 Remove Extensions With Composer


### PR DESCRIPTION
…talled with Composer

refs https://github.com/TYPO3-Documentation/TYPO3CMS-Reference-CoreApi/issues/1449