### PR TITLE
[TASK] Add third-party tools chapter with information on Rector

### DIFF
--- a/Documentation/Index.rst
+++ b/Documentation/Index.rst
@@ -55,6 +55,19 @@ Upgrading TYPO3
 
          .. rst-class:: card-header h3
 
+            .. rubric:: :ref:`Third-party Tools <Tools>`
+
+         .. container:: card-body
+
+            Tools and resources developed by the community that can assist with common
+            upgrade and maintenance tasks.
+
+   .. container:: col-md-6 pl-0 pr-3 py-3 m-0
+
+      .. container:: card px-0 h-100
+
+         .. rst-class:: card-header h3
+
             .. rubric:: :ref:`Legacy upgrade guide <Legacy>`
 
          .. container:: card-body
@@ -92,6 +105,7 @@ Upgrading TYPO3
    Minor/Index
    Major/Index
    UpgradingExtensions/Index
+   Tools/Index
    Legacy/Index
    MigrateToComposer/Index
    MigrateContent/Index

--- a/Documentation/Tools/Index.rst
+++ b/Documentation/Tools/Index.rst
@@ -1,0 +1,33 @@
+.. include:: /Includes.rst.txt
+
+.. _tools:
+
+=================
+Third-party tools
+=================
+
+A collection of third-party resources than can assist with upgrade and
+maintenance tasks.
+
+Rector for TYPO3
+================
+
+Rector for TYPO3 was created to help developers upgrade their TYPO3 installations
+and ensure their extensions support the latest versions of PHP and TYPO3. Rector
+scans your code base and replaces any deprecated functions with an appropriate
+replacement. Rector can also help ensure better code quality by means of automated refactoring.
+
+Rector can run as a standalone package or it can be integrated with your CI pipeline.
+
+
+Find out more
+-------------
+
+- `Rector GitHub <https://github.com/rectorphp/rector>`__ - use this link to install Rector for your TYPO3 project.
+- `Rector for TYPO3 <https://github.com/sabbelasichon/typo3-rector>`__ - development page only.
+
+Support
+-------
+
+Visit the `TYPO3 Slack <https://typo3.slack.com/>`__ and search for the `#ext-typo3-rector`
+channel. You can also open an issue or start a discussion on the projects GitHub page.

--- a/Documentation/Tools/Index.rst
+++ b/Documentation/Tools/Index.rst
@@ -23,8 +23,7 @@ Rector can run as a standalone package or it can be integrated with your CI pipe
 Find out more
 -------------
 
-- `Rector GitHub <https://github.com/rectorphp/rector>`__ - use this link to install Rector for your TYPO3 project.
-- `Rector for TYPO3 <https://github.com/sabbelasichon/typo3-rector>`__ - development page only.
+- `Rector for TYPO3 <https://github.com/sabbelasichon/typo3-rector>`__.
 
 Support
 -------

--- a/Documentation/Tools/Index.rst
+++ b/Documentation/Tools/Index.rst
@@ -28,5 +28,5 @@ Resources
 Support
 -------
 
-Visit the `TYPO3 Slack <https://typo3.slack.com/>`__ and search for the `#ext-typo3-rector`
+Visit the `TYPO3 Slack <https://typo3.org/community/meet/chat-slack>`__ and search for the `#ext-typo3-rector`
 channel. You can also open an issue or start a discussion on the projects GitHub page.

--- a/Documentation/Tools/Index.rst
+++ b/Documentation/Tools/Index.rst
@@ -19,11 +19,11 @@ replacement. Rector can also help ensure better code quality by means of automat
 
 Rector can run as a standalone package or it can be integrated with your CI pipeline.
 
+Resources
+---------
 
-Find out more
--------------
-
-- `Rector for TYPO3 <https://github.com/sabbelasichon/typo3-rector>`__.
+- `Rector for TYPO3 GitHub page <https://github.com/sabbelasichon/typo3-rector>`__.
+- `Best practice guide <https://github.com/sabbelasichon/typo3-rector/blob/main/docs/best_practice_guide.md>`__.
 
 Support
 -------

--- a/Documentation/Tools/Index.rst
+++ b/Documentation/Tools/Index.rst
@@ -6,7 +6,7 @@
 Third-party tools
 =================
 
-A collection of third-party resources than can assist with upgrade and
+A collection of third-party resources that can assist with upgrade and
 maintenance tasks.
 
 Rector for TYPO3


### PR DESCRIPTION
This commit adds a new section to the Upgrade Guide
titled "third party tools".

The first being TYPO3 Rector.

[+] Add "Third-party Tools" section with card
[+] Add information about T3 Rector

Resolves #208 