### PR TITLE
[BUGFIX] Show "Convert Global Extensions" content on PreUpgrade

### DIFF
--- a/Documentation/Major/PreupgradeTasks/Index.rst
+++ b/Documentation/Major/PreupgradeTasks/Index.rst
@@ -65,4 +65,4 @@ Resolve Deprecations
 Convert Global Extensions
 =========================
 
-.. include:: Deprecations.rst.txt
+.. include:: ConvertGlobalExtensions.rst.txt


### PR DESCRIPTION
The content of this paragraph
https://docs.typo3.org/m/typo3/guide-installation/main/en-us/Major/PreupgradeTasks/Index.html#resolve-deprecations
was duplicated to the paragraph below.

Relates: https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-Installation/commit/f0055e47732c5245383537515a5f7f2004c1e724#diff-8afec1494836e379370792f680edc7efe24a58cde4d23e73264941c2d634f1c3R68
