### PR TITLE
Ignore /var/ folder in .gitignore

### DIFF
--- a/Documentation/MigrateToComposer/CoWorking.rst
+++ b/Documentation/MigrateToComposer/CoWorking.rst
@@ -25,6 +25,8 @@ A :file:`.gitignore` file could look like this:
 .. code-block:: none
    :caption: /.gitignore
 
+   /var/*
+   !/var/labels
    /vendor/*
    /public/index.php
    /public/typo3/*


### PR DESCRIPTION
This is taken from https://github.com/TYPO3/TYPO3.CMS.BaseDistribution/blob/v11.5.1/.gitignore which does the same