### PR TITLE
Change default rst indentation to 4 spaces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = space
-indent_size = 3
+indent_size = 4
 max_line_length = 80
 
 # MD-Files


### PR DESCRIPTION
refs https://github.com/TYPO3-Documentation/T3DocTeam/issues/194