### PR TITLE
Remove hint to subtree split

### DIFF
--- a/Documentation/MigrateToComposer/MigrationSteps.rst
+++ b/Documentation/MigrateToComposer/MigrationSteps.rst
@@ -115,15 +115,8 @@ You have to decide by yourself, which syntax fits best to your needs.
 .. _composer-migration-require-all:
 .. _composer-migration-require-subtree-packages:
 
-Install the core
+Install the Core
 ----------------
-
-.. hint::
-
-   Since version 9 TYPO3 must be installed using individual `typo3/cms-*` packages
-   (see "subtree split" for details). This means that you will only install the
-   system extensions you really need. This, among others, increases security. The
-   former `typo3/cms` package cannot be installed anymore.
 
 Install the system extensions:
 


### PR DESCRIPTION
This has been the practice since TYPO3 9.5 so the old hint can be removed for version 12 and 11

Releases: main, 11.5
Resolves https://github.com/TYPO3-Documentation/TYPO3CMS-Guide-Installation/issues/287