### PR TITLE
[TASK] Link Composer introductory documents

### DIFF
--- a/Documentation/MigrateToComposer/MigrationSteps.rst
+++ b/Documentation/MigrateToComposer/MigrationSteps.rst
@@ -5,6 +5,14 @@
 Migration steps
 ===============
 
+..  note::
+    If you are not familiar with Composer, please read the following documents
+    first:
+
+    *   `Introduction to Composer <https://getcomposer.org/doc/00-intro.md>`__
+    *   `Basic usage of Composer <https://getcomposer.org/doc/01-basic-usage.md>`__
+
+
 Delete files
 ============
 


### PR DESCRIPTION
A user should read the introductory documents before starting migrating to a Composer installation, if they are not familiar with it.

Releases: main, 11.5, 10.4