### PR TITLE
[BUGFIX] Include correct section for "Convert global extensions"

### DIFF
--- a/Documentation/Major/PreupgradeTasks/Index.rst
+++ b/Documentation/Major/PreupgradeTasks/Index.rst
@@ -65,4 +65,4 @@ Resolve Deprecations
 Convert Global Extensions
 =========================
 
-.. include:: Deprecations.rst.txt
+.. include:: ConvertGlobalExtensions.rst.txt


### PR DESCRIPTION
This is wrong only in 11.5 branch.

Releases: 11.5