### PR TITLE
[CI] Update Ubuntu version

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     name: Backport
     steps:
       - name: Backport


### PR DESCRIPTION
This avoids the error on CI run:

This is a scheduled Ubuntu-18.04 brownout. The Ubuntu-18.04 environment is deprecated and will be removed on April 1st, 2023. GitHub Actions has encountered an internal error when running your job.

Releases: main