### PR TITLE
[TASK] Remove typo3conf folder from .gitignore suggestion

### DIFF
--- a/Documentation/MigrateToComposer/VersionControl.rst
+++ b/Documentation/MigrateToComposer/VersionControl.rst
@@ -44,7 +44,6 @@ A :file:`.gitignore` file could look like this:
     /vendor/*
     /public/index.php
     /public/typo3/*
-    /public/typo3conf/ext/*
 
 Checkout from version control system
 ====================================


### PR DESCRIPTION
With the mandatory usage of typo3/cms-composer-installers v5 in TYPO3 v12 the typo3conf folder is gone.

Releases: main, 12.4