### PR TITLE
Update ReferenceIndex.rst.txt

### DIFF
--- a/Documentation/Major/PreupgradeTasks/ReferenceIndex.rst.txt
+++ b/Documentation/Major/PreupgradeTasks/ReferenceIndex.rst.txt
@@ -37,7 +37,7 @@ Without command line
 --------------------
 
 Still in your old TYPO3 version, go to the
-:guilabel:`Admin Tools > System DB check` module and use the
+:guilabel:`System > DB check` module and use the
 :guilabel:`Manage Reference Index` function.
 
 Click on :guilabel:`Update reference index` to update the reference index. In


### PR DESCRIPTION
Updated the location of the "Manage Reference Index" in the TYPO3 backend. Unless I'm mistaken, in my version it's located in "System > DB Check". 

I noticed this while upgrading the patch version of my TYPO3 core from 11.5.24 -> 11.5.28, so while I don't know if it's version-specific, the following screenshot suggests that it was the case at least since version 7: https://docs.typo3.org/m/typo3/tutorial-getting-started/10.4/en-us/_images/BackendDbCheckModule.png

I have only contributed to TYPO3CMS-Reference-CoreApi in the past, I have to admit to not having checked if the guidelines vary significantly. Please let me know if there are any inadequacies with my current PR, I will be more than happy to correct them!