### PR TITLE
Corrects backend module path for "DB Check" (#344)

### DIFF
--- a/Documentation/Major/PreupgradeTasks/ReferenceIndex.rst.txt
+++ b/Documentation/Major/PreupgradeTasks/ReferenceIndex.rst.txt
@@ -37,7 +37,7 @@ Without command line
 --------------------
 
 Still in your old TYPO3 version, go to the
-:guilabel:`Admin Tools > System DB check` module and use the
+:guilabel:`System > DB check` module and use the
 :guilabel:`Manage Reference Index` function.
 
 Click on :guilabel:`Update reference index` to update the reference index. In


### PR DESCRIPTION
Updated the location of the "Manage Reference Index" in the TYPO3 backend. Unless I'm mistaken, in my version it's located in "System > DB Check".