### PR TITLE
[BUGFIX] Remove rendering warning

### DIFF
--- a/Documentation/ApplyingCorePatches/Index.rst
+++ b/Documentation/ApplyingCorePatches/Index.rst
@@ -105,6 +105,7 @@ Apply the patch by running the following command:
 If applying the patch fails, you may get a cryptic error message like:
 
 .. code-block:: none
+
    Example error message
 
    Could not apply patch! Skipping. The error was: Cannot apply patch patches/Bug-98106.diff


### PR DESCRIPTION
    ./Documentation/ApplyingCorePatches/Index.rst:107: ERROR: Error in "code-block" directive:
    maximum 1 argument(s) allowed, 4 supplied.

    .. code-block:: none
       Example error message

       Could not apply patch! Skipping. The error was: Cannot apply patch patches/Bug-98106.diff

Releases: main, 12.4, 11.5