### PR TITLE
[DOCS] Improve docs on using composer patch

### DIFF
--- a/Documentation/ApplyingCorePatches/Index.rst
+++ b/Documentation/ApplyingCorePatches/Index.rst
@@ -57,12 +57,17 @@ add one.
      "typo3/cms": {
        "web-dir": "public"
      },
+     "composer-exit-on-patch-failure": true,
      "patches": {
        "typo3/cms-core": {
          "Bug #98106 fix something":"patches/Bug-98106.diff"
        }
      }
    }
+
+.. note::
+   Use :bash:`composer-exit-on-patch-failure` to exit the running process on patch failures.
+   Otherwise, you may not notice the error.
 
 The patch itself looks like this:
 


### PR DESCRIPTION
Add note to use `composer-exit-on-patch-failure` to get notice about an error on patching.